### PR TITLE
Fix missing temperature value when adding recipe steps

### DIFF
--- a/AmerikaKamaraFirin/View/ReceteDuzenle.xaml.cs
+++ b/AmerikaKamaraFirin/View/ReceteDuzenle.xaml.cs
@@ -105,6 +105,7 @@ namespace AmerikaKamaraFirin.View
                 {
                     AdimNo = _recete.Adimlar.Count + 1,
                     HedefSicaklik1 = sicaklik1,
+                    HedefSicaklik2 = sicaklik2,
                     SureDakika = sure,
                     BacaAciklik1 = baca1,
                     BacaAciklik2 = baca2


### PR DESCRIPTION
## Summary
- set `HedefSicaklik2` when adding a new recipe step in `ReceteDuzenle`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d957d03e4832faba6a9f9cdd622a5