### PR TITLE
Fix touch input on custom keyboard windows

### DIFF
--- a/AmerikaKamaraFirin/View/Keyboard.xaml
+++ b/AmerikaKamaraFirin/View/Keyboard.xaml
@@ -12,7 +12,8 @@
     AllowsTransparency="True"
     Background="Transparent"
     Deactivated="Window_Deactivated"
-    IsManipulationEnabled="True"
+    <!-- Allow touch input to generate mouse events for buttons -->
+    IsManipulationEnabled="False"
     KeyDown="Window_KeyDown"
     Loaded="Window_Loaded"
     MouseLeftButtonDown="Window_MouseLeftButtonDown"
@@ -31,7 +32,6 @@
             <Setter Property="BorderBrush" Value="#666" />
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="IsManipulationEnabled" Value="True" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">

--- a/AmerikaKamaraFirin/View/Numpad.xaml
+++ b/AmerikaKamaraFirin/View/Numpad.xaml
@@ -13,7 +13,8 @@
     Background="Transparent"
     Deactivated="Window_Deactivated"
     Foreground="White"
-    IsManipulationEnabled="True"
+    <!-- Allow touch input to generate mouse events for buttons -->
+    IsManipulationEnabled="False"
     KeyDown="Window_KeyDown"
     Loaded="Window_Loaded"
     MouseLeftButtonDown="Window_MouseLeftButtonDown"
@@ -32,7 +33,6 @@
             <Setter Property="BorderBrush" Value="#666" />
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="Cursor" Value="Hand" />
-            <Setter Property="IsManipulationEnabled" Value="True" />
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="Button">


### PR DESCRIPTION
## Summary
- allow Windows to interpret touch as mouse input by turning off manipulation mode
- remove unnecessary `IsManipulationEnabled` from button style

## Testing
- `dotnet build AmerikaKamaraFirin.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d98654b48832f9318b03c25346cb1